### PR TITLE
Change highlight for stylusExplicitVariable to Identifier

### DIFF
--- a/syntax/stylus.vim
+++ b/syntax/stylus.vim
@@ -47,7 +47,7 @@ syntax match stylusExplicitVariable "\<arguments\|block\>"
       \ nextgroup=stylusColor,stylusUnitInt,stylusUnitFloat,stylusValues,stylusFont,stylusVariable,stylusExplicitVariable,stylusPropertyLookup,stylusParenthesised,stylusOperatorAdditive,stylusOperatorMultiplicative,stylusSubscript,stylusOperatorRelational,stylusOperatorLogical,stylusOperatorExistence,stylusOperatorInstance,stylusOperatorVarDefinition,stylusOperatorTernary,stylusImportant,stylusFunctionName,stylusConditional,stylusHashDotGetter
       \ skipwhite
 
-highlight def link stylusExplicitVariable NonText
+highlight def link stylusExplicitVariable Identifier
 
 " ===============================================
 " OPERATORS


### PR DESCRIPTION
Stylus variables highlighted as NonText now. NonText highlight rule is for non printable chars like line breaks or tabs, it usually has low contrast and it is not easily readable. I've changed it to Identifier to make it easy to read.

**Before:**
<img width="381" alt="screen shot 2018-03-19 at 4 51 01 pm" src="https://user-images.githubusercontent.com/9132/37628617-69679fba-2b97-11e8-842d-c03b89f28984.png">

**After:**
<img width="389" alt="screen shot 2018-03-19 at 4 51 17 pm" src="https://user-images.githubusercontent.com/9132/37628637-791bb694-2b97-11e8-85ae-d51c87e53265.png">

