### PR TITLE
Match class/id selectors with consecutive hyphens

### DIFF
--- a/syntax/stylus.vim
+++ b/syntax/stylus.vim
@@ -260,7 +260,7 @@ syn match stylusSelectorElement "\(^\|\s\)\@<=\*\($\|\s\)\@="
 highlight def link stylusSelectorElement Statement
 
 " CSS Class
-syntax region stylusSelectorClass start="\." skip="\w-\@=" end="\(\w\|-\)\(\W\|$\)\@="
+syntax region stylusSelectorClass start="\." skip="\w-\@=" end="\(\w\|-+\)\(\W\|$\)\@="
       \ contained
       \ keepend
       \ nextgroup=stylusSelectorClass,stylusSelectorId,stylusSelectorCombinator,stylusSelectorElement,stylusSelectorAttribute,stylusSelectorPseudo,stylusSelectorReference,stylusSelectorPartialReference,stylusInterpolationSelectors,stylusOptional,stylusOptional
@@ -274,7 +274,7 @@ syntax match stylusSelectorClass "\.{\@="
 highlight def link stylusSelectorClass Identifier
 
 " CSS Id
-syntax region stylusSelectorId start="#" skip="\w-\@=" end="\(\w\|-\)\(\W\|$\)\@="
+syntax region stylusSelectorId start="#" skip="\w-\@=" end="\(\w\|-+\)\(\W\|$\)\@="
       \ contained
       \ keepend
       \ nextgroup=stylusSelectorClass,stylusSelectorId,stylusSelectorCombinator,stylusSelectorElement,stylusSelectorAttribute,stylusSelectorPseudo,stylusSelectorReference,stylusSelectorPartialReference,stylusInterpolationSelectors,stylusOptional


### PR DESCRIPTION
Solves incomplete highlighting for classes and ids that include BEM modifiers, for example.